### PR TITLE
Add configurable start screen image

### DIFF
--- a/bot/database/methods/read.py
+++ b/bot/database/methods/read.py
@@ -8,7 +8,10 @@ from sqlalchemy import func, exists, select, inspect as sa_inspect
 
 from bot.database.models import Database, User, ItemValues, Goods, Categories, Role, BoughtGoods, \
     Operations, ReferralEarnings, Permission
-from bot.database.models.main import PromoCodes, PromoCodeUsages, CartItems, Reviews, StockSubscriptions
+from bot.database.models.main import (
+    PromoCodes, PromoCodeUsages, CartItems, Reviews, StockSubscriptions,
+    StorefrontSettings,
+)
 from bot.misc.caching import get_cache_manager, single_flight
 
 F = TypeVar('F', bound=Callable[..., Coroutine[Any, Any, Any]])
@@ -66,6 +69,15 @@ async def _fetch_one_dict(model, *whereclauses) -> dict | None:
     async with Database().session() as s:
         obj = (await s.execute(select(model).where(*whereclauses))).scalars().first()
         return _obj_to_dict(obj, model) if obj else None
+
+
+async def get_start_image_file_id() -> str | None:
+    """Return the configured /start Telegram photo file_id, if any."""
+    async with Database().session() as s:
+        return (await s.execute(
+            select(StorefrontSettings.start_image_file_id)
+            .where(StorefrontSettings.id == 1)
+        )).scalar()
 
 
 # --- Async implementations ---

--- a/bot/database/methods/update.py
+++ b/bot/database/methods/update.py
@@ -1,3 +1,5 @@
+import hashlib
+
 from sqlalchemy import exc, select, update
 
 from bot.database.methods.read import invalidate_user_cache, invalidate_item_cache, \
@@ -5,9 +7,66 @@ from bot.database.methods.read import invalidate_user_cache, invalidate_item_cac
 from bot.database.methods.cache_utils import safe_create_task
 from bot.database.methods.create import CART_MAX_QTY_PER_ITEM
 from bot.database.models import User, Goods, Categories, BoughtGoods, Role
-from bot.database.models.main import PromoCodes, CartItems
+from bot.database.models.main import PromoCodes, CartItems, StorefrontSettings, AuditLog
 from bot.database import Database
+from bot.database.methods.audit import log_audit
 from bot.logger_mesh import logger
+
+
+async def set_start_image_file_id(
+    file_id: str | None,
+    admin_id: int,
+    *,
+    expected_file_id_fingerprint: str | None = None,
+) -> bool | None:
+    """Atomically set or clear the /start image and its required audit row.
+
+    Returns whether an image was configured before this change, or None when a
+    removal confirmation is stale. The singleton row is seeded by the migration;
+    its absence is an operational error rather than a condition to repair
+    silently in a request handler.
+    """
+    async with Database().session() as s:
+        settings = (await s.execute(
+            select(StorefrontSettings)
+            .where(StorefrontSettings.id == 1)
+            .with_for_update()
+        )).scalars().one_or_none()
+        if settings is None:
+            raise RuntimeError("storefront settings row is missing")
+
+        previously_configured = bool(settings.start_image_file_id)
+        if file_id is None:
+            if expected_file_id_fingerprint is None:
+                return None
+            current_fingerprint = (
+                hashlib.sha256(settings.start_image_file_id.encode()).hexdigest()
+                if settings.start_image_file_id else None
+            )
+            if current_fingerprint != expected_file_id_fingerprint:
+                return None
+        if file_id is None and not previously_configured:
+            return False
+
+        settings.start_image_file_id = file_id
+        action = (
+            "start_image_removed" if file_id is None
+            else "start_image_replaced" if previously_configured
+            else "start_image_added"
+        )
+        await log_audit(
+            action,
+            user_id=admin_id,
+            details=f"previously_configured={str(previously_configured).lower()}",
+            session=s,
+        )
+        if not any(
+            isinstance(obj, AuditLog) and obj.action == action
+            for obj in s.new
+        ):
+            raise RuntimeError("required storefront audit row was not added")
+
+        return previously_configured
 
 
 async def set_role(telegram_id: int, role: int) -> None:

--- a/bot/database/models/main.py
+++ b/bot/database/models/main.py
@@ -280,6 +280,17 @@ class ReferralEarnings(Database.BASE):
         return f"#{self.id}"
 
 
+class StorefrontSettings(Database.BASE):
+    """Singleton settings row for storefront appearance."""
+    __tablename__ = 'storefront_settings'
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    start_image_file_id: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+
+    __table_args__ = (
+        CheckConstraint('id = 1', name='ck_storefront_settings_singleton'),
+    )
+
+
 class AuditLog(Database.BASE):
     __tablename__ = 'audit_log'
     id: Mapped[int] = mapped_column(Integer, primary_key=True)

--- a/bot/handlers/admin/__init__.py
+++ b/bot/handlers/admin/__init__.py
@@ -9,11 +9,13 @@ from .user_management import router as user_management_router
 from .role_management import router as role_management_router
 from .promo_management import router as promo_management_router
 from .sale_management import router as sale_management_router
+from .start_image_settings import router as start_image_settings_router
 
 from aiogram import Router
 
 router = Router()
 router.include_router(main_router)
+router.include_router(start_image_settings_router)
 router.include_router(adding_position_router)
 router.include_router(broadcast_router)
 router.include_router(categories_management_router)

--- a/bot/handlers/admin/main.py
+++ b/bot/handlers/admin/main.py
@@ -8,6 +8,7 @@ from bot.database.methods import check_role_cached
 from bot.filters import HasPermissionFilter
 from bot.database.models import Permission
 from bot.database.methods.audit import log_audit
+from bot.handlers.other import transition_to_text
 from bot.middleware.security import get_auth_middleware
 
 router = Router()
@@ -23,7 +24,8 @@ async def console_callback_handler(call: CallbackQuery, state: FSMContext):
     if Permission.has_any_admin_perm(role):
         mw = get_auth_middleware()
         maintenance = mw.maintenance_mode if mw else False
-        await call.message.edit_text(
+        await transition_to_text(
+            call.message,
             localize("admin.menu.main"),
             reply_markup=admin_console_keyboard(maintenance_mode=maintenance, role=role),
         )

--- a/bot/handlers/admin/start_image_settings.py
+++ b/bot/handlers/admin/start_image_settings.py
@@ -1,0 +1,213 @@
+import hashlib
+
+from aiogram import F, Router
+from aiogram.fsm.context import FSMContext
+from aiogram.types import CallbackQuery, Message
+from sqlalchemy.exc import SQLAlchemyError
+
+from bot.database.methods import (
+    check_role_cached,
+    get_start_image_file_id,
+    set_start_image_file_id,
+)
+from bot.database.models import Permission
+from bot.filters import HasPermissionFilter
+from bot.handlers.user.main import render_start_screen
+from bot.i18n import localize
+from bot.keyboards import back, simple_buttons, start_image_settings_keyboard
+from bot.logger_mesh import logger
+from bot.states import StorefrontSettingsFSM
+
+router = Router()
+
+
+async def _authorize_callback(call: CallbackQuery) -> int | None:
+    role = await check_role_cached(call.from_user.id) or 0
+    if Permission.granted(role, Permission.SETTINGS_MANAGE):
+        return role
+    await call.answer(localize("admin.menu.rights"), show_alert=True)
+    return None
+
+
+async def _authorize_message(message: Message) -> bool:
+    role = await check_role_cached(message.from_user.id) or 0
+    if Permission.granted(role, Permission.SETTINGS_MANAGE):
+        return True
+    await message.answer(localize("admin.menu.rights"))
+    return False
+
+
+def _settings_card_text(configured: bool, notice: str | None = None) -> str:
+    status_key = (
+        "admin.start_image.status_configured"
+        if configured else "admin.start_image.status_empty"
+    )
+    card = f"{localize('admin.start_image.title')}\n\n{localize(status_key)}"
+    return f"{notice}\n\n{card}" if notice else card
+
+
+async def _answer_settings_card(
+    message: Message,
+    configured: bool,
+    notice: str | None = None,
+) -> None:
+    await message.answer(
+        _settings_card_text(configured, notice),
+        reply_markup=start_image_settings_keyboard(configured),
+    )
+
+
+@router.callback_query(
+    F.data == "start_image_settings",
+    HasPermissionFilter(permission=Permission.SETTINGS_MANAGE),
+)
+async def start_image_settings_handler(call: CallbackQuery, state: FSMContext):
+    if await _authorize_callback(call) is None:
+        return
+    await state.clear()
+    configured = bool(await get_start_image_file_id())
+    await call.message.edit_text(
+        _settings_card_text(configured),
+        reply_markup=start_image_settings_keyboard(configured),
+    )
+
+
+@router.callback_query(
+    F.data == "start_image_upload",
+    HasPermissionFilter(permission=Permission.SETTINGS_MANAGE),
+)
+async def start_image_upload_handler(call: CallbackQuery, state: FSMContext):
+    if await _authorize_callback(call) is None:
+        return
+    await call.message.edit_text(
+        localize("admin.start_image.prompt"),
+        reply_markup=back("start_image_settings"),
+    )
+    await state.set_state(StorefrontSettingsFSM.waiting_start_image)
+
+
+@router.message(
+    StorefrontSettingsFSM.waiting_start_image,
+    F.photo,
+    HasPermissionFilter(permission=Permission.SETTINGS_MANAGE),
+)
+async def save_start_image_handler(message: Message, state: FSMContext):
+    if not await _authorize_message(message):
+        return
+    file_id = message.photo[-1].file_id
+    try:
+        previously_configured = await set_start_image_file_id(
+            file_id,
+            message.from_user.id,
+        )
+    except (SQLAlchemyError, RuntimeError):
+        logger.error("start_image_persistence_failed")
+        await message.answer(
+            localize("admin.start_image.save_failed"),
+            reply_markup=back("start_image_settings"),
+        )
+        return
+
+    await state.clear()
+    notice_key = (
+        "admin.start_image.replaced"
+        if previously_configured else "admin.start_image.added"
+    )
+    await _answer_settings_card(message, True, localize(notice_key))
+
+
+@router.message(
+    StorefrontSettingsFSM.waiting_start_image,
+    HasPermissionFilter(permission=Permission.SETTINGS_MANAGE),
+)
+async def reject_non_photo_handler(message: Message):
+    if not await _authorize_message(message):
+        return
+    await message.answer(
+        localize("admin.start_image.photo_required"),
+        reply_markup=back("start_image_settings"),
+    )
+
+
+@router.callback_query(
+    F.data == "start_image_remove",
+    HasPermissionFilter(permission=Permission.SETTINGS_MANAGE),
+)
+async def start_image_remove_handler(call: CallbackQuery, state: FSMContext):
+    if await _authorize_callback(call) is None:
+        return
+    current_file_id = await get_start_image_file_id()
+    if not current_file_id:
+        await state.clear()
+        await call.message.edit_text(
+            _settings_card_text(False, localize("admin.start_image.already_empty")),
+            reply_markup=start_image_settings_keyboard(False),
+        )
+        return
+
+    await state.set_state(StorefrontSettingsFSM.confirming_start_image_removal)
+    await state.update_data(
+        start_image_fingerprint=hashlib.sha256(current_file_id.encode()).hexdigest()
+    )
+    await call.message.edit_text(
+        localize("admin.start_image.remove_confirm"),
+        reply_markup=simple_buttons([
+            (localize("btn.yes"), "start_image_remove_confirm"),
+            (localize("btn.no"), "start_image_settings"),
+        ]),
+    )
+
+
+@router.callback_query(
+    StorefrontSettingsFSM.confirming_start_image_removal,
+    F.data == "start_image_remove_confirm",
+    HasPermissionFilter(permission=Permission.SETTINGS_MANAGE),
+)
+async def start_image_remove_confirm_handler(call: CallbackQuery, state: FSMContext):
+    if await _authorize_callback(call) is None:
+        return
+    expected_fingerprint = (await state.get_data()).get("start_image_fingerprint")
+    if not expected_fingerprint:
+        await state.clear()
+        await call.answer(localize("admin.start_image.stale"), show_alert=True)
+        return
+
+    try:
+        removed = await set_start_image_file_id(
+            None,
+            call.from_user.id,
+            expected_file_id_fingerprint=expected_fingerprint,
+        )
+    except (SQLAlchemyError, RuntimeError):
+        logger.error("start_image_persistence_failed")
+        await call.answer(localize("admin.start_image.save_failed"), show_alert=True)
+        return
+
+    await state.clear()
+    if removed is None:
+        configured = bool(await get_start_image_file_id())
+        await call.answer(localize("admin.start_image.stale"), show_alert=True)
+        await call.message.edit_text(
+            _settings_card_text(configured),
+            reply_markup=start_image_settings_keyboard(configured),
+        )
+        return
+
+    notice_key = "admin.start_image.removed" if removed else "admin.start_image.already_empty"
+    await call.message.edit_text(
+        _settings_card_text(False, localize(notice_key)),
+        reply_markup=start_image_settings_keyboard(False),
+    )
+
+
+@router.callback_query(
+    F.data == "start_image_preview",
+    HasPermissionFilter(permission=Permission.SETTINGS_MANAGE),
+)
+async def start_image_preview_handler(call: CallbackQuery):
+    role = await _authorize_callback(call)
+    if role is None:
+        return
+    await call.answer()
+    await call.message.answer(localize("admin.start_image.preview_label"))
+    await render_start_screen(call.message, role)

--- a/bot/handlers/other.py
+++ b/bot/handlers/other.py
@@ -3,7 +3,7 @@ import re
 from urllib.parse import urlparse
 
 from aiogram import Router, F
-from aiogram.types import CallbackQuery
+from aiogram.types import CallbackQuery, Message
 from aiogram.exceptions import TelegramBadRequest, TelegramForbiddenError
 from aiogram.enums import ChatMemberStatus
 
@@ -11,6 +11,41 @@ from bot.misc import EnvKeys
 from bot.logger_mesh import logger
 
 router = Router()
+
+_EXPECTED_DELETE_FAILURES = (
+    "message can't be deleted",
+    "message to delete not found",
+    "not enough rights to delete",
+)
+
+
+def _is_expected_delete_failure(error: Exception) -> bool:
+    description = (getattr(error, "message", "") or str(error)).lower()
+    return any(marker in description for marker in _EXPECTED_DELETE_FAILURES)
+
+
+async def delete_for_text_transition(message: Message) -> None:
+    """Delete an obsolete media message before sending a text destination.
+
+    Telegram can legitimately refuse deletion for old/already-removed messages
+    or missing delete rights. Those cases may fall back to sending the new
+    screen alongside the old one; unrelated API errors must still propagate.
+    """
+    try:
+        await message.delete()
+    except (TelegramBadRequest, TelegramForbiddenError) as error:
+        if not _is_expected_delete_failure(error):
+            raise
+
+
+async def transition_to_text(message: Message, text: str, **kwargs) -> None:
+    """Edit a text message in place, or replace a media message with text."""
+    if getattr(message, "text", None) is not None:
+        await message.edit_text(text, **kwargs)
+        return
+
+    await delete_for_text_transition(message)
+    await message.answer(text, **kwargs)
 
 
 # Close message

--- a/bot/handlers/user/main.py
+++ b/bot/handlers/user/main.py
@@ -13,8 +13,14 @@ from bot.database.methods import (
     select_user_operations_total, select_user_items, check_user_cached
 )
 from bot.database.methods.read import get_cart_count, invalidate_user_cache
+from bot.database.methods.read import get_start_image_file_id
 from bot.database.methods.lazy_queries import query_user_operations_history
-from bot.handlers.other import check_sub_channel, _parse_channel_username
+from bot.handlers.other import (
+    check_sub_channel,
+    delete_for_text_transition,
+    transition_to_text,
+    _parse_channel_username,
+)
 from bot.keyboards import main_menu, back, profile_keyboard, check_sub
 from bot.misc import EnvKeys
 from bot.misc.metrics import get_metrics
@@ -22,6 +28,54 @@ from bot.i18n import localize
 from bot.logger_mesh import logger
 
 router = Router()
+
+TELEGRAM_PHOTO_CAPTION_LIMIT = 1024
+_UNUSABLE_START_IMAGE_ERRORS = (
+    "wrong file identifier/http url specified",
+    "wrong file identifier",
+    "file reference expired",
+    "file_reference_expired",
+)
+
+
+def _is_unusable_start_image_error(error: TelegramBadRequest) -> bool:
+    description = (getattr(error, "message", "") or str(error)).lower()
+    return any(marker in description for marker in _UNUSABLE_START_IMAGE_ERRORS)
+
+
+async def render_start_screen(
+    message: Message,
+    role: int,
+    *,
+    replace_current: bool = False,
+) -> None:
+    """Render the production start screen for /start and admin preview."""
+    text = localize("menu.title")
+    channel_username = _parse_channel_username()
+    markup = main_menu(role=role, channel=channel_username, helper=EnvKeys.HELPER_ID)
+    file_id = await get_start_image_file_id()
+
+    if not file_id:
+        if replace_current:
+            await transition_to_text(message, text, reply_markup=markup)
+        else:
+            await message.answer(text, reply_markup=markup)
+        return
+
+    if replace_current:
+        await delete_for_text_transition(message)
+
+    try:
+        if len(text) <= TELEGRAM_PHOTO_CAPTION_LIMIT:
+            await message.answer_photo(photo=file_id, caption=text, reply_markup=markup)
+        else:
+            await message.answer_photo(photo=file_id)
+            await message.answer(text, reply_markup=markup)
+    except TelegramBadRequest as error:
+        if not _is_unusable_start_image_error(error):
+            raise
+        logger.warning("start_screen_image_unusable")
+        await message.answer(text, reply_markup=markup)
 
 
 async def _ensure_user(user_id: int) -> dict | None:
@@ -146,8 +200,7 @@ async def start(message: Message, state: FSMContext):
             await _delete_quietly(message)
             return
 
-    markup = main_menu(role=role_data, channel=channel_username, helper=EnvKeys.HELPER_ID)
-    await message.answer(localize("menu.title"), reply_markup=markup)
+    await render_start_screen(message, role_data)
     await _delete_quietly(message)
     await state.clear()
 
@@ -162,10 +215,7 @@ async def back_to_menu_callback_handler(call: CallbackQuery, state: FSMContext):
 
     role = await check_role_cached(user_id) or 0
 
-    channel_username = _parse_channel_username()
-
-    markup = main_menu(role=role, channel=channel_username, helper=EnvKeys.HELPER_ID)
-    await call.message.edit_text(localize("menu.title"), reply_markup=markup)
+    await render_start_screen(call.message, role, replace_current=True)
     await state.clear()
 
 
@@ -176,7 +226,11 @@ async def rules_callback_handler(call: CallbackQuery, state: FSMContext):
     """
     rules_data = EnvKeys.RULES
     if rules_data:
-        await call.message.edit_text(rules_data, reply_markup=back("back_to_menu"))
+        await transition_to_text(
+            call.message,
+            rules_data,
+            reply_markup=back("back_to_menu"),
+        )
     else:
         await call.answer(localize("rules.not_set"))
     await state.clear()
@@ -211,7 +265,12 @@ async def profile_callback_handler(call: CallbackQuery, state: FSMContext):
         f"{localize('profile.purchased_count', count=items)}"
     )
     try:
-        await call.message.edit_text(text, reply_markup=markup, parse_mode='HTML')
+        await transition_to_text(
+            call.message,
+            text,
+            reply_markup=markup,
+            parse_mode='HTML',
+        )
     except TelegramBadRequest as e:
         if "message is not modified" not in str(e):
             raise
@@ -304,5 +363,3 @@ async def _show_operations_page(call: CallbackQuery, state: FSMContext, user_id:
     kb.row(InlineKeyboardButton(text=localize("btn.back"), callback_data="profile"))
 
     await call.message.edit_text("\n".join(lines), reply_markup=kb.as_markup())
-
-

--- a/bot/handlers/user/shop_and_goods.py
+++ b/bot/handlers/user/shop_and_goods.py
@@ -24,6 +24,7 @@ from bot.database.methods.lazy_queries import query_item_reviews, query_goods_se
 from bot.database.methods.transactions import redeem_balance_promo
 from bot.database.methods.audit import log_audit_bg
 from bot.database.models import Permission
+from bot.handlers.other import transition_to_text
 from bot.keyboards import item_info, back, lazy_paginated_keyboard
 from bot.keyboards.inline import simple_buttons, rating_keyboard
 from aiogram.types import InlineKeyboardButton
@@ -187,7 +188,11 @@ async def _show_categories_page(call: CallbackQuery, state: FSMContext, page: in
         )]],
     )
 
-    await call.message.edit_text(localize("shop.categories.title"), reply_markup=markup)
+    await transition_to_text(
+        call.message,
+        localize("shop.categories.title"),
+        reply_markup=markup,
+    )
     await state.update_data(
         category_page_items=list(page_items),
         category_page_num=page,

--- a/bot/i18n/strings.py
+++ b/bot/i18n/strings.py
@@ -402,6 +402,26 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         "admin.maintenance.enabled": "✅ Режим тех. работ включён",
         "admin.maintenance.disabled": "✅ Режим тех. работ выключён",
 
+        # === Admin: Start Screen Image ===
+        "admin.menu.start_image": "🖼 Изображение экрана /start",
+        "admin.start_image.title": "🖼 <b>Изображение экрана /start</b>",
+        "admin.start_image.status_configured": "Статус: изображение настроено.",
+        "admin.start_image.status_empty": "Статус: изображение не настроено.",
+        "admin.start_image.add": "➕ Добавить изображение",
+        "admin.start_image.replace": "🔄 Заменить изображение",
+        "admin.start_image.remove": "🗑 Удалить изображение",
+        "admin.start_image.preview": "👁 Предпросмотр",
+        "admin.start_image.prompt": "Отправьте фотографию для экрана /start.",
+        "admin.start_image.photo_required": "⚠️ Требуется фотография. Отправьте её как фото.",
+        "admin.start_image.added": "✅ Изображение добавлено.",
+        "admin.start_image.replaced": "✅ Изображение заменено.",
+        "admin.start_image.removed": "✅ Изображение удалено.",
+        "admin.start_image.already_empty": "ℹ️ Изображение уже не настроено.",
+        "admin.start_image.save_failed": "❌ Не удалось сохранить настройку. Попробуйте ещё раз.",
+        "admin.start_image.remove_confirm": "Удалить изображение экрана /start?",
+        "admin.start_image.stale": "⚠️ Настройка изменилась. Откройте её снова.",
+        "admin.start_image.preview_label": "👁 Предпросмотр экрана /start:",
+
         # === Promo Codes ===
         "btn.apply_promo": "🏷 Применить промокод",
         "btn.remove_promo": "❌ Убрать промокод",
@@ -938,6 +958,26 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         "admin.menu.maintenance_off": "🔧 Maintenance: OFF",
         "admin.maintenance.enabled": "✅ Maintenance mode enabled",
         "admin.maintenance.disabled": "✅ Maintenance mode disabled",
+
+        # === Admin: Start Screen Image ===
+        "admin.menu.start_image": "🖼 /start screen image",
+        "admin.start_image.title": "🖼 <b>/start screen image</b>",
+        "admin.start_image.status_configured": "Status: an image is configured.",
+        "admin.start_image.status_empty": "Status: no image is configured.",
+        "admin.start_image.add": "➕ Add image",
+        "admin.start_image.replace": "🔄 Replace image",
+        "admin.start_image.remove": "🗑 Remove image",
+        "admin.start_image.preview": "👁 Preview",
+        "admin.start_image.prompt": "Send a photo for the /start screen.",
+        "admin.start_image.photo_required": "⚠️ A photo is required. Send it as a photo.",
+        "admin.start_image.added": "✅ Image added.",
+        "admin.start_image.replaced": "✅ Image replaced.",
+        "admin.start_image.removed": "✅ Image removed.",
+        "admin.start_image.already_empty": "ℹ️ No image is currently configured.",
+        "admin.start_image.save_failed": "❌ Could not save the setting. Please try again.",
+        "admin.start_image.remove_confirm": "Remove the /start screen image?",
+        "admin.start_image.stale": "⚠️ The setting changed. Open it again.",
+        "admin.start_image.preview_label": "👁 /start screen preview:",
 
         # === Promo Codes ===
         "btn.apply_promo": "🏷 Apply promo code",

--- a/bot/keyboards/inline.py
+++ b/bot/keyboards/inline.py
@@ -61,11 +61,29 @@ def admin_console_keyboard(maintenance_mode: bool = False, role: int = 127) -> I
     if role & Permission.BROADCAST:
         kb.button(text=localize("admin.menu.broadcast"), callback_data="send_message")
     if role & Permission.SETTINGS_MANAGE:
+        kb.button(text=localize("admin.menu.start_image"), callback_data="start_image_settings")
         maintenance_key = "admin.menu.maintenance_on" if maintenance_mode else "admin.menu.maintenance_off"
         kb.button(text=localize(maintenance_key), callback_data="toggle_maintenance")
     kb.button(text=localize("btn.back"), callback_data="back_to_menu")
     kb.adjust(1)
     return kb.as_markup()
+
+
+def start_image_settings_keyboard(configured: bool) -> InlineKeyboardMarkup:
+    """Actions for the single configurable /start image."""
+    actions = []
+    if configured:
+        actions.extend([
+            (localize("admin.start_image.replace"), "start_image_upload"),
+            (localize("admin.start_image.remove"), "start_image_remove"),
+        ])
+    else:
+        actions.append((localize("admin.start_image.add"), "start_image_upload"))
+    actions.extend([
+        (localize("admin.start_image.preview"), "start_image_preview"),
+        (localize("btn.back"), "console"),
+    ])
+    return simple_buttons(actions, per_row=1)
 
 
 def simple_buttons(buttons: Iterable[Tuple[str, str]], per_row: int = 1) -> InlineKeyboardMarkup:

--- a/bot/states/__init__.py
+++ b/bot/states/__init__.py
@@ -7,3 +7,4 @@ from .goods_state import GoodsFSM, AddItemFSM, UpdateItemFSM, SaleFSM
 from .role_state import RoleMgmtFSM
 from .promo_state import PromoFSM
 from .review_state import ReviewFSM
+from .storefront_settings_state import StorefrontSettingsFSM

--- a/bot/states/storefront_settings_state.py
+++ b/bot/states/storefront_settings_state.py
@@ -1,0 +1,6 @@
+from aiogram.filters.state import StatesGroup, State
+
+
+class StorefrontSettingsFSM(StatesGroup):
+    waiting_start_image = State()
+    confirming_start_image_removal = State()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   redis:
     image: redis:7-alpine
+    environment:
+      REDIS_PASSWORD: ${REDIS_PASSWORD:-changeme_redis_pass}
     command: redis-server --appendonly yes --requirepass "${REDIS_PASSWORD:-changeme_redis_pass}"
     volumes:
       - redis_data:/data

--- a/migrations/versions/a4b5c6d7e8f9_add_storefront_settings.py
+++ b/migrations/versions/a4b5c6d7e8f9_add_storefront_settings.py
@@ -1,0 +1,45 @@
+"""add storefront settings
+
+Revision ID: a4b5c6d7e8f9
+Revises: d7e8f9a0b1c2
+Create Date: 2026-07-29 00:00:00.000000
+
+Stores the reusable Telegram photo file_id for the optional /start image.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+# revision identifiers, used by Alembic.
+revision: str = 'a4b5c6d7e8f9'
+down_revision: Union[str, None] = 'd7e8f9a0b1c2'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if 'storefront_settings' not in inspect(bind).get_table_names():
+        op.create_table(
+            'storefront_settings',
+            sa.Column('id', sa.Integer(), nullable=False),
+            sa.Column('start_image_file_id', sa.Text(), nullable=True),
+            sa.CheckConstraint('id = 1', name='ck_storefront_settings_singleton'),
+            sa.PrimaryKeyConstraint('id'),
+        )
+
+    exists = bind.execute(
+        sa.text('SELECT 1 FROM storefront_settings WHERE id = 1')
+    ).scalar()
+    if not exists:
+        bind.execute(
+            sa.text('INSERT INTO storefront_settings (id, start_image_file_id) VALUES (1, NULL)')
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if 'storefront_settings' in inspect(bind).get_table_names():
+        op.drop_table('storefront_settings')

--- a/tests/test_start_image.py
+++ b/tests/test_start_image.py
@@ -1,0 +1,847 @@
+import hashlib
+from importlib import import_module
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiogram.exceptions import TelegramBadRequest
+from sqlalchemy import delete, select
+from sqlalchemy.exc import SQLAlchemyError
+
+import bot.database.methods.audit as audit_module
+from bot.database.main import Database
+from bot.database.methods.read import check_user, get_start_image_file_id
+from bot.database.methods.update import set_start_image_file_id
+from bot.database.models.main import AuditLog, Permission, StorefrontSettings
+from bot.filters import HasPermissionFilter
+from bot.handlers.admin import main as admin_main_handlers
+from bot.handlers.admin import start_image_settings as settings_handlers
+from bot.handlers.other import transition_to_text
+from bot.handlers.user import main as user_handlers
+from bot.handlers.user import shop_and_goods as shop_handlers
+from bot.i18n import localize
+from bot.keyboards import main_menu, start_image_settings_keyboard
+from bot.states import ShopStates, StorefrontSettingsFSM
+
+update_module = import_module("bot.database.methods.update")
+
+
+SETTINGS_ROLE = Permission.USE | Permission.SETTINGS_MANAGE
+FEATURE_AUDIT_ACTIONS = (
+    "start_image_added",
+    "start_image_replaced",
+    "start_image_removed",
+)
+
+
+def _callback_data(markup) -> set[str]:
+    return {
+        button.callback_data
+        for row in markup.inline_keyboard
+        for button in row
+        if button.callback_data
+    }
+
+
+def _bad_request(message: str) -> TelegramBadRequest:
+    return TelegramBadRequest(method=MagicMock(), message=message)
+
+
+def _as_photo_callback(call):
+    """Make a callback originate from the photo-with-caption /start message."""
+    call.message.text = None
+    call.message.caption = "menu.title"
+    call.message.photo = [MagicMock(file_id="fake-large-photo-id")]
+    call.message.reply_markup = MagicMock()
+    call.message.delete = AsyncMock()
+    call.message.answer = AsyncMock()
+    call.message.answer_photo = AsyncMock()
+    return call
+
+
+@pytest.fixture
+async def storefront_row():
+    """Seed the singleton row normally created by the Alembic migration."""
+    async with Database().session() as session:
+        await session.execute(delete(StorefrontSettings))
+        await session.execute(
+            delete(AuditLog).where(AuditLog.action.in_(FEATURE_AUDIT_ACTIONS))
+        )
+        session.add(StorefrontSettings(id=1, start_image_file_id=None))
+
+    yield
+
+    async with Database().session() as session:
+        await session.execute(delete(StorefrontSettings))
+        await session.execute(
+            delete(AuditLog).where(AuditLog.action.in_(FEATURE_AUDIT_ACTIONS))
+        )
+
+
+class TestStartScreenRenderer:
+    async def test_without_image_preserves_text_and_role_aware_keyboard(self, make_message):
+        message = make_message()
+        message.answer_photo = AsyncMock()
+
+        with patch.object(
+            user_handlers, "get_start_image_file_id", new_callable=AsyncMock, return_value=None
+        ), patch.object(user_handlers, "_parse_channel_username", return_value=None), patch.object(
+            user_handlers.EnvKeys, "HELPER_ID", ""
+        ):
+            await user_handlers.render_start_screen(message, SETTINGS_ROLE)
+
+        message.answer.assert_awaited_once()
+        assert message.answer.await_args.args[0] == "menu.title"
+        assert {"shop", "rules", "profile", "console"}.issubset(
+            _callback_data(message.answer.await_args.kwargs["reply_markup"])
+        )
+        message.answer_photo.assert_not_awaited()
+
+    async def test_configured_image_uses_original_text_and_keyboard(self, make_message):
+        message = make_message()
+        message.answer_photo = AsyncMock()
+
+        with patch.object(
+            user_handlers,
+            "get_start_image_file_id",
+            new_callable=AsyncMock,
+            return_value="fake-large-photo-id",
+        ), patch.object(user_handlers, "_parse_channel_username", return_value=None), patch.object(
+            user_handlers.EnvKeys, "HELPER_ID", ""
+        ):
+            await user_handlers.render_start_screen(message, SETTINGS_ROLE)
+
+        message.answer_photo.assert_awaited_once()
+        kwargs = message.answer_photo.await_args.kwargs
+        assert kwargs["photo"] == "fake-large-photo-id"
+        assert kwargs["caption"] == "menu.title"
+        assert {"shop", "rules", "profile", "console"}.issubset(
+            _callback_data(kwargs["reply_markup"])
+        )
+        message.answer.assert_not_awaited()
+
+    async def test_long_text_is_not_truncated(self, make_message):
+        message = make_message()
+        message.answer_photo = AsyncMock()
+        long_text = "x" * 1025
+
+        with patch.object(
+            user_handlers,
+            "get_start_image_file_id",
+            new_callable=AsyncMock,
+            return_value="fake-large-photo-id",
+        ), patch.object(user_handlers, "localize", return_value=long_text), patch.object(
+            user_handlers, "_parse_channel_username", return_value=None
+        ), patch.object(user_handlers.EnvKeys, "HELPER_ID", ""):
+            await user_handlers.render_start_screen(message, SETTINGS_ROLE)
+
+        message.answer_photo.assert_awaited_once_with(photo="fake-large-photo-id")
+        message.answer.assert_awaited_once()
+        assert message.answer.await_args.args[0] == long_text
+        assert len(message.answer.await_args.args[0]) == 1025
+        assert "console" in _callback_data(message.answer.await_args.kwargs["reply_markup"])
+
+    async def test_unavailable_file_id_falls_back_without_logging_it(self, make_message):
+        message = make_message()
+        message.answer_photo = AsyncMock(side_effect=_bad_request(
+            "Bad Request: wrong file identifier/http url specified"
+        ))
+
+        with patch.object(
+            user_handlers,
+            "get_start_image_file_id",
+            new_callable=AsyncMock,
+            return_value="fake-unavailable-photo-id",
+        ), patch.object(user_handlers, "_parse_channel_username", return_value=None), patch.object(
+            user_handlers.EnvKeys, "HELPER_ID", ""
+        ), patch.object(user_handlers.logger, "warning") as warning:
+            await user_handlers.render_start_screen(message, SETTINGS_ROLE)
+
+        message.answer.assert_awaited_once()
+        assert message.answer.await_args.args[0] == "menu.title"
+        assert "console" in _callback_data(message.answer.await_args.kwargs["reply_markup"])
+        warning.assert_called_once_with("start_screen_image_unusable")
+        assert "fake-unavailable-photo-id" not in repr(warning.call_args_list)
+
+    async def test_unrelated_telegram_error_propagates(self, make_message):
+        message = make_message()
+        message.answer_photo = AsyncMock(side_effect=_bad_request("Bad Request: chat not found"))
+
+        with patch.object(
+            user_handlers,
+            "get_start_image_file_id",
+            new_callable=AsyncMock,
+            return_value="fake-large-photo-id",
+        ), patch.object(user_handlers, "_parse_channel_username", return_value=None), patch.object(
+            user_handlers.EnvKeys, "HELPER_ID", ""
+        ), pytest.raises(TelegramBadRequest, match="chat not found"):
+            await user_handlers.render_start_screen(message, SETTINGS_ROLE)
+
+        message.answer.assert_not_awaited()
+
+    async def test_real_start_flow_uses_shared_renderer(self, make_message, fsm_context):
+        message = make_message(text="/start", user_id=710001)
+
+        with patch.object(
+            user_handlers, "check_role_cached", new_callable=AsyncMock, return_value=SETTINGS_ROLE
+        ), patch.object(user_handlers, "_parse_channel_username", return_value=None), patch.object(
+            user_handlers, "render_start_screen", new_callable=AsyncMock
+        ) as renderer:
+            await user_handlers.start(message, fsm_context)
+
+        renderer.assert_awaited_once_with(message, SETTINGS_ROLE)
+
+    async def test_preview_calls_shared_renderer_with_admin_role(self, make_callback_query):
+        call = make_callback_query(data="start_image_preview", user_id=710002)
+
+        with patch.object(
+            settings_handlers,
+            "check_role_cached",
+            new_callable=AsyncMock,
+            return_value=SETTINGS_ROLE,
+        ), patch.object(
+            settings_handlers, "render_start_screen", new_callable=AsyncMock
+        ) as renderer:
+            await settings_handlers.start_image_preview_handler(call)
+
+        call.message.answer.assert_awaited_once_with(localize("admin.start_image.preview_label"))
+        renderer.assert_awaited_once_with(call.message, SETTINGS_ROLE)
+
+
+class TestPhotoStartNavigation:
+    async def test_console_from_photo_replaces_media_with_text(
+        self, make_callback_query, fsm_context
+    ):
+        call = _as_photo_callback(
+            make_callback_query(data="console", user_id=715001)
+        )
+
+        with patch.object(
+            admin_main_handlers,
+            "check_role_cached",
+            new_callable=AsyncMock,
+            return_value=SETTINGS_ROLE,
+        ), patch.object(admin_main_handlers, "get_auth_middleware", return_value=None):
+            await admin_main_handlers.console_callback_handler(call, fsm_context)
+
+        call.message.edit_text.assert_not_awaited()
+        call.message.delete.assert_awaited_once()
+        call.message.answer.assert_awaited_once()
+        assert call.message.answer.await_args.args[0] == localize("admin.menu.main")
+
+    async def test_shop_from_photo_replaces_media_with_text(
+        self, make_callback_query, fsm_context
+    ):
+        call = _as_photo_callback(make_callback_query(data="shop", user_id=715002))
+
+        with patch.object(shop_handlers, "get_metrics", return_value=None), patch.object(
+            shop_handlers,
+            "lazy_paginated_keyboard",
+            new_callable=AsyncMock,
+            return_value=MagicMock(),
+        ):
+            await shop_handlers.shop_callback_handler(call, fsm_context)
+
+        call.message.edit_text.assert_not_awaited()
+        call.message.delete.assert_awaited_once()
+        call.message.answer.assert_awaited_once()
+        assert await fsm_context.get_state() == ShopStates.viewing_categories
+
+    async def test_profile_from_photo_replaces_media_with_text(
+        self, make_callback_query, fsm_context, user_factory
+    ):
+        await user_factory(telegram_id=715003, balance=25)
+        call = _as_photo_callback(make_callback_query(data="profile", user_id=715003))
+
+        with patch.object(user_handlers.EnvKeys, "PAY_CURRENCY", "RUB"), patch.object(
+            user_handlers.EnvKeys, "REFERRAL_PERCENT", 0
+        ):
+            await user_handlers.profile_callback_handler(call, fsm_context)
+
+        call.message.edit_text.assert_not_awaited()
+        call.message.delete.assert_awaited_once()
+        call.message.answer.assert_awaited_once()
+        assert "25" in call.message.answer.await_args.args[0]
+
+    async def test_rules_from_photo_replaces_media_with_text(
+        self, make_callback_query, fsm_context
+    ):
+        call = _as_photo_callback(make_callback_query(data="rules", user_id=715004))
+
+        with patch.object(user_handlers.EnvKeys, "RULES", "Local rules"):
+            await user_handlers.rules_callback_handler(call, fsm_context)
+
+        call.message.edit_text.assert_not_awaited()
+        call.message.delete.assert_awaited_once()
+        call.message.answer.assert_awaited_once_with(
+            "Local rules",
+            reply_markup=call.message.answer.await_args.kwargs["reply_markup"],
+        )
+
+    def test_all_main_menu_callbacks_use_covered_entry_paths(self):
+        callbacks = _callback_data(main_menu(role=SETTINGS_ROLE))
+        assert callbacks == {"shop", "rules", "profile", "console"}
+
+    async def test_text_source_still_edits_in_place(self, make_callback_query):
+        call = make_callback_query(data="rules", user_id=715005)
+        call.message.text = "menu.title"
+        call.message.delete = AsyncMock()
+        call.message.answer = AsyncMock()
+
+        await transition_to_text(call.message, "Destination", reply_markup=MagicMock())
+
+        call.message.edit_text.assert_awaited_once()
+        call.message.delete.assert_not_awaited()
+        call.message.answer.assert_not_awaited()
+
+    async def test_expected_delete_failure_falls_back_to_new_text(
+        self, make_callback_query
+    ):
+        call = _as_photo_callback(make_callback_query(user_id=715006))
+        call.message.delete.side_effect = _bad_request(
+            "Bad Request: message can't be deleted"
+        )
+
+        await transition_to_text(call.message, "Destination")
+
+        call.message.answer.assert_awaited_once_with("Destination")
+
+    async def test_unrelated_delete_error_propagates(self, make_callback_query):
+        call = _as_photo_callback(make_callback_query(user_id=715007))
+        call.message.delete.side_effect = _bad_request("Bad Request: chat not found")
+
+        with pytest.raises(TelegramBadRequest, match="chat not found"):
+            await transition_to_text(call.message, "Destination")
+
+        call.message.answer.assert_not_awaited()
+
+    async def test_back_to_menu_restores_configured_photo_and_preserves_setting(
+        self, storefront_row, make_callback_query, fsm_context, caplog
+    ):
+        await set_start_image_file_id("fake-large-photo-id", 715008)
+        call = make_callback_query(data="back_to_menu", user_id=715008)
+        call.message.text = "profile.caption"
+        call.message.delete = AsyncMock()
+        call.message.answer = AsyncMock()
+        call.message.answer_photo = AsyncMock()
+
+        with patch.object(
+            user_handlers, "_ensure_user", new_callable=AsyncMock, return_value={}
+        ), patch.object(
+            user_handlers,
+            "check_role_cached",
+            new_callable=AsyncMock,
+            return_value=SETTINGS_ROLE,
+        ), patch.object(user_handlers, "_parse_channel_username", return_value=None), patch.object(
+            user_handlers.EnvKeys, "HELPER_ID", ""
+        ), caplog.at_level("WARNING", logger="bot"):
+            await user_handlers.back_to_menu_callback_handler(call, fsm_context)
+
+        call.message.edit_text.assert_not_awaited()
+        call.message.delete.assert_awaited_once()
+        call.message.answer_photo.assert_awaited_once()
+        assert call.message.answer_photo.await_args.kwargs["caption"] == "menu.title"
+        assert await get_start_image_file_id() == "fake-large-photo-id"
+        assert "fake-large-photo-id" not in caplog.text
+
+    async def test_back_to_menu_without_image_edits_existing_text(
+        self, storefront_row, make_callback_query, fsm_context
+    ):
+        call = make_callback_query(data="back_to_menu", user_id=715009)
+        call.message.text = "profile.caption"
+        call.message.delete = AsyncMock()
+        call.message.answer = AsyncMock()
+        call.message.answer_photo = AsyncMock()
+
+        with patch.object(
+            user_handlers, "_ensure_user", new_callable=AsyncMock, return_value={}
+        ), patch.object(
+            user_handlers,
+            "check_role_cached",
+            new_callable=AsyncMock,
+            return_value=SETTINGS_ROLE,
+        ), patch.object(user_handlers, "_parse_channel_username", return_value=None), patch.object(
+            user_handlers.EnvKeys, "HELPER_ID", ""
+        ):
+            await user_handlers.back_to_menu_callback_handler(call, fsm_context)
+
+        call.message.edit_text.assert_awaited_once()
+        assert call.message.edit_text.await_args.args[0] == "menu.title"
+        call.message.delete.assert_not_awaited()
+        call.message.answer.assert_not_awaited()
+        call.message.answer_photo.assert_not_awaited()
+
+
+class TestStartImageAdminFlow:
+    @pytest.mark.parametrize("configured", [False, True])
+    async def test_settings_card_reports_state(
+        self, configured, make_callback_query, fsm_context
+    ):
+        call = make_callback_query(data="start_image_settings", user_id=720001)
+        stored = "fake-large-photo-id" if configured else None
+
+        with patch.object(
+            settings_handlers,
+            "check_role_cached",
+            new_callable=AsyncMock,
+            return_value=SETTINGS_ROLE,
+        ), patch.object(
+            settings_handlers,
+            "get_start_image_file_id",
+            new_callable=AsyncMock,
+            return_value=stored,
+        ):
+            await settings_handlers.start_image_settings_handler(call, fsm_context)
+
+        expected_status = localize(
+            "admin.start_image.status_configured" if configured
+            else "admin.start_image.status_empty"
+        )
+        assert expected_status in call.message.edit_text.await_args.args[0]
+        callbacks = _callback_data(call.message.edit_text.await_args.kwargs["reply_markup"])
+        labels = {
+            button.text
+            for row in call.message.edit_text.await_args.kwargs["reply_markup"].inline_keyboard
+            for button in row
+        }
+        assert ("start_image_remove" in callbacks) is configured
+        assert "start_image_upload" in callbacks
+        assert "start_image_preview" in callbacks
+        expected_action = localize(
+            "admin.start_image.replace" if configured else "admin.start_image.add"
+        )
+        assert expected_action in labels
+
+    @pytest.mark.parametrize("configured", [False, True], ids=["add", "replace"])
+    async def test_add_and_replace_enter_upload_state(
+        self, configured, make_callback_query, fsm_context
+    ):
+        assert "start_image_upload" in _callback_data(start_image_settings_keyboard(configured))
+        call = make_callback_query(data="start_image_upload", user_id=720002)
+
+        with patch.object(
+            settings_handlers,
+            "check_role_cached",
+            new_callable=AsyncMock,
+            return_value=SETTINGS_ROLE,
+        ):
+            await settings_handlers.start_image_upload_handler(call, fsm_context)
+
+        assert await fsm_context.get_state() == StorefrontSettingsFSM.waiting_start_image
+
+    @pytest.mark.parametrize(
+        ("previously_configured", "notice_key"),
+        [
+            (False, "admin.start_image.added"),
+            (True, "admin.start_image.replaced"),
+        ],
+        ids=["add", "replace"],
+    )
+    async def test_photo_uses_largest_size_and_clears_only_after_persistence(
+        self, previously_configured, notice_key, make_message, fsm_context
+    ):
+        message = make_message(user_id=720003)
+        message.photo = [
+            MagicMock(file_id="fake-small-photo-id"),
+            MagicMock(file_id="fake-large-photo-id"),
+        ]
+        await fsm_context.set_state(StorefrontSettingsFSM.waiting_start_image)
+
+        async def persist(file_id, admin_id):
+            assert file_id == "fake-large-photo-id"
+            assert admin_id == 720003
+            assert await fsm_context.get_state() == StorefrontSettingsFSM.waiting_start_image
+            return previously_configured
+
+        with patch.object(
+            settings_handlers,
+            "check_role_cached",
+            new_callable=AsyncMock,
+            return_value=SETTINGS_ROLE,
+        ), patch.object(
+            settings_handlers,
+            "set_start_image_file_id",
+            new_callable=AsyncMock,
+            side_effect=persist,
+        ) as setter:
+            await settings_handlers.save_start_image_handler(message, fsm_context)
+
+        setter.assert_awaited_once_with("fake-large-photo-id", 720003)
+        assert await fsm_context.get_state() is None
+        assert localize(notice_key) in message.answer.await_args.args[0]
+        callbacks = _callback_data(message.answer.await_args.kwargs["reply_markup"])
+        assert {"start_image_upload", "start_image_remove", "start_image_preview"}.issubset(callbacks)
+        assert "fake-large-photo-id" not in str(message.answer.await_args_list)
+
+    @pytest.mark.parametrize(
+        "unsupported", ["text", "document", "video", "animation", "sticker"]
+    )
+    async def test_unsupported_input_is_rejected_and_state_remains(
+        self, unsupported, make_message, fsm_context
+    ):
+        message = make_message(text="not a photo", user_id=720004)
+        setattr(message, unsupported, MagicMock())
+        await fsm_context.set_state(StorefrontSettingsFSM.waiting_start_image)
+
+        with patch.object(
+            settings_handlers,
+            "check_role_cached",
+            new_callable=AsyncMock,
+            return_value=SETTINGS_ROLE,
+        ):
+            await settings_handlers.reject_non_photo_handler(message)
+
+        assert await fsm_context.get_state() == StorefrontSettingsFSM.waiting_start_image
+        assert localize("admin.start_image.photo_required") in message.answer.await_args.args[0]
+
+    async def test_cancellation_preserves_existing_image(
+        self, make_callback_query, fsm_context
+    ):
+        call = make_callback_query(data="start_image_settings", user_id=720005)
+        await fsm_context.set_state(StorefrontSettingsFSM.waiting_start_image)
+
+        with patch.object(
+            settings_handlers,
+            "check_role_cached",
+            new_callable=AsyncMock,
+            return_value=SETTINGS_ROLE,
+        ), patch.object(
+            settings_handlers,
+            "get_start_image_file_id",
+            new_callable=AsyncMock,
+            return_value="fake-large-photo-id",
+        ), patch.object(
+            settings_handlers, "set_start_image_file_id", new_callable=AsyncMock
+        ) as setter:
+            await settings_handlers.start_image_settings_handler(call, fsm_context)
+
+        setter.assert_not_awaited()
+        assert await fsm_context.get_state() is None
+
+    async def test_persistence_failure_keeps_state_and_has_no_success_response(
+        self, make_message, fsm_context, caplog
+    ):
+        message = make_message(user_id=720006)
+        message.photo = [MagicMock(file_id="fake-large-photo-id")]
+        await fsm_context.set_state(StorefrontSettingsFSM.waiting_start_image)
+
+        with patch.object(
+            settings_handlers,
+            "check_role_cached",
+            new_callable=AsyncMock,
+            return_value=SETTINGS_ROLE,
+        ), patch.object(
+            settings_handlers,
+            "set_start_image_file_id",
+            new_callable=AsyncMock,
+            side_effect=SQLAlchemyError("database unavailable"),
+        ), caplog.at_level("ERROR", logger="bot"):
+            await settings_handlers.save_start_image_handler(message, fsm_context)
+
+        assert await fsm_context.get_state() == StorefrontSettingsFSM.waiting_start_image
+        assert message.answer.await_count == 1
+        response = message.answer.await_args.args[0]
+        assert localize("admin.start_image.save_failed") == response
+        assert localize("admin.start_image.added") not in response
+        assert localize("admin.start_image.replaced") not in response
+        assert "fake-large-photo-id" not in caplog.text
+
+    async def test_removal_requires_confirmation(self, make_callback_query, fsm_context):
+        call = make_callback_query(data="start_image_remove", user_id=720007)
+
+        with patch.object(
+            settings_handlers,
+            "check_role_cached",
+            new_callable=AsyncMock,
+            return_value=SETTINGS_ROLE,
+        ), patch.object(
+            settings_handlers,
+            "get_start_image_file_id",
+            new_callable=AsyncMock,
+            return_value="fake-large-photo-id",
+        ), patch.object(
+            settings_handlers, "set_start_image_file_id", new_callable=AsyncMock
+        ) as setter:
+            await settings_handlers.start_image_remove_handler(call, fsm_context)
+
+        setter.assert_not_awaited()
+        assert await fsm_context.get_state() == StorefrontSettingsFSM.confirming_start_image_removal
+        callbacks = _callback_data(call.message.edit_text.await_args.kwargs["reply_markup"])
+        assert "start_image_remove_confirm" in callbacks
+
+    async def test_removal_is_safe_when_already_empty(self, make_callback_query, fsm_context):
+        call = make_callback_query(data="start_image_remove", user_id=720008)
+
+        with patch.object(
+            settings_handlers,
+            "check_role_cached",
+            new_callable=AsyncMock,
+            return_value=SETTINGS_ROLE,
+        ), patch.object(
+            settings_handlers,
+            "get_start_image_file_id",
+            new_callable=AsyncMock,
+            return_value=None,
+        ), patch.object(
+            settings_handlers, "set_start_image_file_id", new_callable=AsyncMock
+        ) as setter:
+            await settings_handlers.start_image_remove_handler(call, fsm_context)
+
+        setter.assert_not_awaited()
+        assert await fsm_context.get_state() is None
+        assert localize("admin.start_image.already_empty") in call.message.edit_text.await_args.args[0]
+
+    async def test_stale_confirmation_does_not_report_removal(
+        self, make_callback_query, fsm_context
+    ):
+        call = make_callback_query(data="start_image_remove_confirm", user_id=720009)
+        await fsm_context.set_state(StorefrontSettingsFSM.confirming_start_image_removal)
+        await fsm_context.update_data(start_image_fingerprint="stale-fingerprint")
+
+        with patch.object(
+            settings_handlers,
+            "check_role_cached",
+            new_callable=AsyncMock,
+            return_value=SETTINGS_ROLE,
+        ), patch.object(
+            settings_handlers,
+            "set_start_image_file_id",
+            new_callable=AsyncMock,
+            return_value=None,
+        ), patch.object(
+            settings_handlers,
+            "get_start_image_file_id",
+            new_callable=AsyncMock,
+            return_value="fake-large-photo-id",
+        ):
+            await settings_handlers.start_image_remove_confirm_handler(call, fsm_context)
+
+        assert await fsm_context.get_state() is None
+        assert localize("admin.start_image.stale") in call.answer.await_args.args[0]
+        assert localize("admin.start_image.removed") not in call.message.edit_text.await_args.args[0]
+
+    async def test_confirmed_removal_clears_state_and_returns_card(
+        self, make_callback_query, fsm_context
+    ):
+        call = make_callback_query(data="start_image_remove_confirm", user_id=720010)
+        fingerprint = hashlib.sha256(b"fake-large-photo-id").hexdigest()
+        await fsm_context.set_state(StorefrontSettingsFSM.confirming_start_image_removal)
+        await fsm_context.update_data(start_image_fingerprint=fingerprint)
+
+        with patch.object(
+            settings_handlers,
+            "check_role_cached",
+            new_callable=AsyncMock,
+            return_value=SETTINGS_ROLE,
+        ), patch.object(
+            settings_handlers,
+            "set_start_image_file_id",
+            new_callable=AsyncMock,
+            return_value=True,
+        ) as setter:
+            await settings_handlers.start_image_remove_confirm_handler(call, fsm_context)
+
+        setter.assert_awaited_once_with(
+            None,
+            720010,
+            expected_file_id_fingerprint=fingerprint,
+        )
+        assert await fsm_context.get_state() is None
+        assert localize("admin.start_image.removed") in call.message.edit_text.await_args.args[0]
+        callbacks = _callback_data(call.message.edit_text.await_args.kwargs["reply_markup"])
+        assert "start_image_remove" not in callbacks
+
+
+class TestStartImageAuthorization:
+    def test_every_feature_handler_keeps_registered_permission_filter(self):
+        callbacks = (
+            settings_handlers.start_image_settings_handler,
+            settings_handlers.start_image_upload_handler,
+            settings_handlers.start_image_remove_handler,
+            settings_handlers.start_image_remove_confirm_handler,
+            settings_handlers.start_image_preview_handler,
+        )
+        messages = (
+            settings_handlers.save_start_image_handler,
+            settings_handlers.reject_non_photo_handler,
+        )
+
+        registrations = [
+            *settings_handlers.router.callback_query.handlers,
+            *settings_handlers.router.message.handlers,
+        ]
+        for callback in (*callbacks, *messages):
+            registration = next(item for item in registrations if item.callback is callback)
+            permission_filters = [
+                item.callback
+                for item in registration.filters
+                if isinstance(item.callback, HasPermissionFilter)
+            ]
+            assert len(permission_filters) == 1
+            assert permission_filters[0].permission == Permission.SETTINGS_MANAGE
+
+    async def test_direct_unauthorized_callbacks_cannot_read_or_modify_configuration(
+        self, make_callback_query, fsm_context
+    ):
+        get_setting = AsyncMock(return_value="fake-large-photo-id")
+        set_setting = AsyncMock()
+        renderer = AsyncMock()
+
+        with patch.object(
+            settings_handlers,
+            "check_role_cached",
+            new_callable=AsyncMock,
+            return_value=Permission.USE,
+        ), patch.object(settings_handlers, "get_start_image_file_id", get_setting), patch.object(
+            settings_handlers, "set_start_image_file_id", set_setting
+        ), patch.object(settings_handlers, "render_start_screen", renderer):
+            calls = [
+                make_callback_query(data="start_image_settings", user_id=730001),
+                make_callback_query(data="start_image_upload", user_id=730001),
+                make_callback_query(data="start_image_remove", user_id=730001),
+                make_callback_query(data="start_image_preview", user_id=730001),
+            ]
+            await settings_handlers.start_image_settings_handler(calls[0], fsm_context)
+            await settings_handlers.start_image_upload_handler(calls[1], fsm_context)
+            await settings_handlers.start_image_remove_handler(calls[2], fsm_context)
+            await settings_handlers.start_image_preview_handler(calls[3])
+
+            confirm_state = type(fsm_context)()
+            await confirm_state.set_state(StorefrontSettingsFSM.confirming_start_image_removal)
+            await confirm_state.update_data(start_image_fingerprint="stale-fingerprint")
+            confirm = make_callback_query(data="start_image_remove_confirm", user_id=730001)
+            await settings_handlers.start_image_remove_confirm_handler(confirm, confirm_state)
+
+        get_setting.assert_not_awaited()
+        set_setting.assert_not_awaited()
+        renderer.assert_not_awaited()
+        for call in [*calls, confirm]:
+            call.answer.assert_awaited_once_with(localize("admin.menu.rights"), show_alert=True)
+
+    async def test_direct_unauthorized_photo_cannot_modify_configuration(
+        self, make_message, fsm_context
+    ):
+        message = make_message(user_id=730002)
+        message.photo = [MagicMock(file_id="fake-large-photo-id")]
+        await fsm_context.set_state(StorefrontSettingsFSM.waiting_start_image)
+
+        with patch.object(
+            settings_handlers,
+            "check_role_cached",
+            new_callable=AsyncMock,
+            return_value=Permission.USE,
+        ), patch.object(
+            settings_handlers, "set_start_image_file_id", new_callable=AsyncMock
+        ) as setter:
+            await settings_handlers.save_start_image_handler(message, fsm_context)
+
+        setter.assert_not_awaited()
+        assert await fsm_context.get_state() == StorefrontSettingsFSM.waiting_start_image
+        message.answer.assert_awaited_once_with(localize("admin.menu.rights"))
+
+    async def test_missing_confirmation_data_cannot_remove_image(
+        self, make_callback_query, fsm_context
+    ):
+        call = make_callback_query(data="start_image_remove_confirm", user_id=730003)
+        await fsm_context.set_state(StorefrontSettingsFSM.confirming_start_image_removal)
+
+        with patch.object(
+            settings_handlers,
+            "check_role_cached",
+            new_callable=AsyncMock,
+            return_value=SETTINGS_ROLE,
+        ), patch.object(
+            settings_handlers, "set_start_image_file_id", new_callable=AsyncMock
+        ) as setter:
+            await settings_handlers.start_image_remove_confirm_handler(call, fsm_context)
+
+        setter.assert_not_awaited()
+        assert await fsm_context.get_state() is None
+        assert localize("admin.start_image.stale") in call.answer.await_args.args[0]
+
+
+class TestStartImagePersistence:
+    async def test_store_replace_and_remove_preserve_unrelated_data(
+        self, storefront_row, user_factory
+    ):
+        await user_factory(telegram_id=740001, balance=321)
+
+        assert await get_start_image_file_id() is None
+        assert await set_start_image_file_id("fake-small-photo-id", 740010) is False
+        assert await get_start_image_file_id() == "fake-small-photo-id"
+
+        assert await set_start_image_file_id("fake-large-photo-id", 740010) is True
+        assert await get_start_image_file_id() == "fake-large-photo-id"
+        assert (await check_user(740001))["balance"] == 321
+
+        fingerprint = hashlib.sha256(b"fake-large-photo-id").hexdigest()
+        assert await set_start_image_file_id(
+            None,
+            740010,
+            expected_file_id_fingerprint=fingerprint,
+        ) is True
+        assert await get_start_image_file_id() is None
+        assert (await check_user(740001))["balance"] == 321
+
+    async def test_stale_removal_preserves_current_value(self, storefront_row):
+        await set_start_image_file_id("fake-large-photo-id", 740011)
+
+        result = await set_start_image_file_id(
+            None,
+            740011,
+            expected_file_id_fingerprint=hashlib.sha256(b"different-photo-id").hexdigest(),
+        )
+
+        assert result is None
+        assert await get_start_image_file_id() == "fake-large-photo-id"
+
+    async def test_transaction_failure_rolls_back_replacement(self, storefront_row):
+        await set_start_image_file_id("fake-small-photo-id", 740012)
+
+        with patch.object(
+            update_module,
+            "log_audit",
+            new_callable=AsyncMock,
+            side_effect=SQLAlchemyError("audit insert failed"),
+        ), pytest.raises(SQLAlchemyError, match="audit insert failed"):
+            await set_start_image_file_id("fake-large-photo-id", 740012)
+
+        assert await get_start_image_file_id() == "fake-small-photo-id"
+
+    async def test_audit_and_logs_contain_no_file_id(self, storefront_row):
+        with patch.object(audit_module.audit_logger, "log") as audit_log:
+            await set_start_image_file_id("fake-small-photo-id", 740013)
+            await set_start_image_file_id("fake-large-photo-id", 740013)
+            fingerprint = hashlib.sha256(b"fake-large-photo-id").hexdigest()
+            await set_start_image_file_id(
+                None,
+                740013,
+                expected_file_id_fingerprint=fingerprint,
+            )
+
+        async with Database().session() as session:
+            rows = (await session.execute(
+                select(AuditLog)
+                .where(AuditLog.action.in_(FEATURE_AUDIT_ACTIONS))
+                .order_by(AuditLog.id)
+            )).scalars().all()
+
+        assert [row.action for row in rows] == list(FEATURE_AUDIT_ACTIONS)
+        assert [row.details for row in rows] == [
+            "previously_configured=false",
+            "previously_configured=true",
+            "previously_configured=true",
+        ]
+        for row in rows:
+            assert row.user_id == 740013
+            assert row.resource_type is None
+            assert row.resource_id is None
+            assert row.ip_address is None
+
+        audit_payload = repr([
+            (row.action, row.user_id, row.details, row.resource_type, row.resource_id)
+            for row in rows
+        ])
+        emitted_logs = repr(audit_log.call_args_list)
+        for file_id in ("fake-small-photo-id", "fake-large-photo-id"):
+            assert file_id not in audit_payload
+            assert file_id not in emitted_logs


### PR DESCRIPTION
## Summary

- add an optional configurable image to the Telegram `/start` screen
- add admin controls to upload, replace, preview, and remove the image
- preserve the original text-only start screen when no image is configured
- support navigation from the photo-based start screen
- add safe fallback when a stored Telegram image is unavailable
- fix Redis healthcheck password configuration

## Testing

- 42 start-image tests passed
- 173 related handler and navigation tests passed
- full test suite: 1000 passed
- Alembic migration upgrade, downgrade, and re-upgrade verified
- manually tested in Telegram with and without a start image
- admin panel, shop, profile, rules, and Back navigation verified
- no errors found in final runtime logs